### PR TITLE
System Chapter Font Footer Fix

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1084,14 +1084,16 @@ void EpubReaderActivity::buildStatusBarTitle(std::string& title, TextRole& title
     if (tocIndex != -1) {
       const auto tocItem = epub->getTocItem(tocIndex);
       title = tocItem.title;
-      titleRole = tocItem.title.empty() ? TextRole::System : TextRole::UserContent;
     }
+    // Keep the built-in small font (System role) so the title matches the page/battery text in the
+    // status bar. Don't promote to UserContent here: that swaps in the SD reader font, whose
+    // smallest size (12pt) towers over the 8pt status text.
     return;
   }
 
   if (SETTINGS.statusBarTitle == CrossPointSettings::STATUS_BAR_TITLE::BOOK_TITLE) {
     title = epub->getTitle();
-    titleRole = title.empty() ? TextRole::System : TextRole::UserContent;
+    // System role (built-in small font) to match the rest of the status bar; see note above.
   }
 }
 

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -500,7 +500,8 @@ void TxtReaderActivity::buildStatusBarTitle(std::string& title, TextRole& titleR
   }
 
   title = txt->getTitle();
-  titleRole = title.empty() ? TextRole::System : TextRole::UserContent;
+  // Keep the built-in small font (System role) so the title matches the page/battery text; using
+  // UserContent would swap in the SD reader font, whose smallest 12pt size towers over the 8pt bar.
 }
 
 void TxtReaderActivity::renderStatusBar() const {


### PR DESCRIPTION
Use system font for chapter title footer, instead of user font. Using user provided fonts can cause overlap with last row if user's smallest custom font is still large.